### PR TITLE
feat: add Ideas Section module with CRUD operations and media handling

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -16,6 +16,7 @@ import { DocumentModule } from './documents/documents.module';
 import { IdeasPageModule } from './pages/ideas-page/ideas-page.module';
 import { InformativeModule } from './informative/informative.module';
 import { ImageSectionModule } from './pages/image-section/image-section.module';
+import { IdeasSectionModule } from './pages/ideas-section/ideas-section.module';
 import { SiteFeedbackModule } from './feedback/site-feedback.module';
 import { AddressesModule } from './modules/addresses/addresses.module';
 import { CoordinatorProfilesModule } from './modules/coordinator-profiles/coordinator-profiles.module';
@@ -44,6 +45,7 @@ import { AcceptedChristsModule } from './modules/accepted-christs/accepted-chris
     IdeasPageModule,
     InformativeModule,
     ImageSectionModule,
+    IdeasSectionModule,
     SiteFeedbackModule,
     AddressesModule,
     CoordinatorProfilesModule,

--- a/src/pages/ideas-section/dto/create-ideas-section.dto.ts
+++ b/src/pages/ideas-section/dto/create-ideas-section.dto.ts
@@ -1,0 +1,28 @@
+import {
+  IsArray,
+  IsBoolean,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { IdeasSectionMediaItemDto } from './ideas-section-media-item.dto';
+
+export class CreateIdeasSectionDto {
+
+  @IsString({ message: 'O campo "title" deve ser uma string.' })
+  title: string;
+
+  @IsString({ message: 'O campo "description" deve ser uma string.' })
+  description: string;
+
+  @IsOptional()
+  @IsBoolean({ message: 'O campo "public" deve ser booleano.' })
+  @Type(() => Boolean)
+  public: boolean = false;
+
+  @IsArray({ message: 'O campo "medias" deve ser um array.' })
+  @ValidateNested({ each: true })
+  @Type(() => IdeasSectionMediaItemDto)
+  medias: IdeasSectionMediaItemDto[];
+}

--- a/src/pages/ideas-section/dto/ideas-section-media-item.dto.ts
+++ b/src/pages/ideas-section/dto/ideas-section-media-item.dto.ts
@@ -1,0 +1,61 @@
+import {
+  IsBoolean,
+  IsEnum,
+  IsNumber,
+  IsOptional,
+  IsString,
+} from 'class-validator';
+import {
+  PlatformType,
+  UploadType,
+} from 'src/share/media/media-item/media-item.entity';
+import { IdeasSectionMediaType } from '../enums/ideas-section-media-type.enum';
+
+export class IdeasSectionMediaItemDto {
+  @IsOptional()
+  @IsString({ message: 'O campo "id" da mídia deve ser uma string.' })
+  id?: string;
+
+  @IsOptional()
+  @IsString({ message: 'O campo "title" da mídia deve ser uma string.' })
+  title?: string;
+
+  @IsOptional()
+  @IsString({ message: 'O campo "description" da mídia deve ser uma string.' })
+  description?: string;
+
+  @IsEnum(UploadType, { message: 'O campo "uploadType" deve ser "upload" ou "link".' })
+  uploadType: UploadType;
+
+  @IsEnum(IdeasSectionMediaType, { 
+    message: 'O campo "mediaType" deve ser "video", "document" ou "image".' 
+  })
+  mediaType: IdeasSectionMediaType;
+
+  @IsBoolean({ message: 'O campo "isLocalFile" deve ser booleano.' })
+  isLocalFile: boolean;
+
+  @IsOptional()
+  @IsString({ message: 'O campo "url" deve ser uma string.' })
+  url?: string;
+
+  @IsOptional()
+  @IsEnum(PlatformType, { message: 'O campo "platformType" deve conter uma plataforma válida.' })
+  platformType?: PlatformType;
+
+  @IsOptional()
+  @IsString({ message: 'O campo "originalName" deve ser uma string.' })
+  originalName?: string;
+
+  @IsOptional()
+  @IsString({ message: 'O campo "fieldKey" deve ser uma string.' })
+  fieldKey?: string;
+
+  @IsOptional()
+  @IsNumber({}, { message: 'O campo "size" deve ser um número.' })
+  size?: number;
+
+  @IsOptional()
+  @IsString({ message: 'O campo "fileField" deve ser uma string.' })
+  fileField?: string;
+}

--- a/src/pages/ideas-section/dto/ideas-section-response.dto.ts
+++ b/src/pages/ideas-section/dto/ideas-section-response.dto.ts
@@ -1,0 +1,37 @@
+import { IdeasSectionEntity } from 'src/pages/ideas-page/entities/ideas-section.entity';
+import { MediaItemEntity } from 'src/share/media/media-item/media-item.entity';
+import { MediaItemDto } from 'src/share/share-dto/media-item-dto';
+
+export class IdeasSectionResponseDto {
+  id: string;
+  title: string;
+  description: string;
+  public: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+  medias: MediaItemDto[];
+
+  static fromEntity(section: IdeasSectionEntity, medias: MediaItemEntity[]): IdeasSectionResponseDto {
+    return {
+      id: section.id,
+      title: section.title,
+      description: section.description,
+      public: section.public,
+      createdAt: section.createdAt,
+      updatedAt: section.updatedAt,
+      medias: medias.map((item) => ({
+        id: item.id,
+        title: item.title,
+        description: item.description,
+        uploadType: item.uploadType,
+        mediaType: item.mediaType,
+        isLocalFile: item.isLocalFile,
+        url: item.url,
+        platformType: item.platformType,
+        originalName: item.originalName,
+        size: item.size,
+        fieldKey: undefined,
+      })),
+    };
+  }
+}

--- a/src/pages/ideas-section/dto/update-ideas-section.dto.ts
+++ b/src/pages/ideas-section/dto/update-ideas-section.dto.ts
@@ -1,0 +1,28 @@
+import {
+  IsArray,
+  IsBoolean,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { IdeasSectionMediaItemDto } from './ideas-section-media-item.dto';
+
+export class UpdateIdeasSectionDto {
+
+  @IsString({ message: 'O campo "title" deve ser uma string.' })
+  title: string;
+
+  @IsString({ message: 'O campo "description" deve ser uma string.' })
+  description: string;
+
+  @IsOptional()
+  @IsBoolean({ message: 'O campo "public" deve ser booleano.' })
+  @Type(() => Boolean)
+  public: boolean = false;
+
+  @IsArray({ message: 'O campo "medias" deve ser um array.' })
+  @ValidateNested({ each: true })
+  @Type(() => IdeasSectionMediaItemDto)
+  medias: IdeasSectionMediaItemDto[];
+}

--- a/src/pages/ideas-section/enums/ideas-section-media-type.enum.ts
+++ b/src/pages/ideas-section/enums/ideas-section-media-type.enum.ts
@@ -1,0 +1,7 @@
+export enum IdeasSectionMediaType {
+  VIDEO = 'video',
+  DOCUMENT = 'document',
+  IMAGE = 'image',
+}
+
+export const IDEAS_SECTION_MEDIA_TYPES = Object.values(IdeasSectionMediaType);

--- a/src/pages/ideas-section/ideas-section.controller.ts
+++ b/src/pages/ideas-section/ideas-section.controller.ts
@@ -1,0 +1,175 @@
+import {
+  Controller,
+  Post,
+  Patch,
+  Delete,
+  Get,
+  Param,
+  Body,
+  UploadedFiles,
+  UseInterceptors,
+  UseGuards,
+  Logger,
+  BadRequestException,
+  NotFoundException,
+} from '@nestjs/common';
+import { AnyFilesInterceptor } from '@nestjs/platform-express';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
+import { AdminRoleGuard } from 'src/auth/guards/role-guard';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { IdeasSectionUpdateService } from './services/ideas-section-update.service';
+import { IdeasSectionGetService } from './services/ideas-section-get.service';
+import { IdeasSectionDeleteService } from './services/ideas-section-delete.service';
+import { IdeasSectionResponseDto } from './dto/ideas-section-response.dto';
+import { CreateIdeasSectionDto } from './dto/create-ideas-section.dto';
+import { UpdateIdeasSectionDto } from './dto/update-ideas-section.dto';
+import { IdeasSectionCreateService } from './services/ideas-section-create.service';
+
+@Controller('ideas-sections')
+export class IdeasSectionController {
+  private readonly logger = new Logger(IdeasSectionController.name);
+
+  constructor(
+    private readonly createService: IdeasSectionCreateService,
+    private readonly updateService: IdeasSectionUpdateService,
+    private readonly getService: IdeasSectionGetService,
+    private readonly deleteService: IdeasSectionDeleteService,
+  ) {}
+
+  @UseGuards(JwtAuthGuard)
+  @Post()
+  @UseInterceptors(AnyFilesInterceptor())
+  async create(
+    @UploadedFiles() files: Express.Multer.File[],
+    @Body('sectionData') raw: string | Buffer,
+  ): Promise<IdeasSectionResponseDto> {
+    this.logger.debug('🚀 Criando nova seção de ideias órfã');
+    this.logger.debug(`📁 Arquivos recebidos: ${files?.length || 0}`);
+    this.logger.debug(`📋 Arquivos: ${JSON.stringify(files?.map(f => ({ fieldname: f.fieldname, originalname: f.originalname })) || [])}`);
+    this.logger.debug(`📄 Raw data type: ${typeof raw}`);
+    this.logger.debug(`📄 Raw data: ${Buffer.isBuffer(raw) ? raw.toString() : raw}`);
+
+    const parsedData = JSON.parse(Buffer.isBuffer(raw) ? raw.toString() : raw);
+    const dto = plainToInstance(CreateIdeasSectionDto, parsedData);
+    const validationErrors = await validate(dto, {
+      whitelist: true,
+      forbidNonWhitelisted: true,
+    });
+
+    if (validationErrors.length > 0) {
+      this.logger.error('❌ Erros de validação:', JSON.stringify(validationErrors, null, 2));
+      throw new BadRequestException('Dados inválidos na requisição');
+    }
+
+    const filesDict: Record<string, Express.Multer.File> = {};
+    files.forEach((file) => (filesDict[file.fieldname] = file));
+    this.logger.debug(`🗂️ FilesDict: ${JSON.stringify(Object.keys(filesDict))}`);
+    const result = await this.createService.createSection(dto, filesDict);
+
+    this.logger.log(`✅ Seção de ideias criada com ID=${result.id}`);
+    return result;
+  }
+
+ @UseGuards(JwtAuthGuard, AdminRoleGuard)
+  @Patch(':id')
+  @UseInterceptors(AnyFilesInterceptor())
+  async update(
+    @Param('id') id: string,
+    @UploadedFiles() files: Express.Multer.File[],
+    @Body('sectionData') raw: string | Buffer,
+  ): Promise<IdeasSectionResponseDto> {
+    this.logger.debug(`🚀 Atualizando seção de ideias ID=${id}`);
+
+    const parsedData = JSON.parse(Buffer.isBuffer(raw) ? raw.toString() : raw);
+    const dto = plainToInstance(UpdateIdeasSectionDto, parsedData);
+    const validationErrors = await validate(dto, {
+      whitelist: true,
+      forbidNonWhitelisted: true,
+    });
+
+    if (validationErrors.length > 0) {
+      this.logger.error('❌ Erros de validação:', JSON.stringify(validationErrors, null, 2));
+      throw new BadRequestException('Dados inválidos na requisição');
+    }
+
+    const filesDict: Record<string, Express.Multer.File> = {};
+    files.forEach((file) => (filesDict[file.fieldname] = file));
+    const result = await this.updateService.updateSection(id, dto, filesDict);
+
+    this.logger.log(`✅ Seção de ideias atualizada com ID=${result.id}`);
+    return result;
+  }
+
+  @UseGuards(JwtAuthGuard, AdminRoleGuard)
+  @Patch(':id/attach/:pageId')
+  @UseInterceptors(AnyFilesInterceptor())
+  async editAndAttachToPage(
+    @Param('id') sectionId: string,
+    @Param('pageId') pageId: string,
+    @UploadedFiles() files: Express.Multer.File[],
+    @Body('sectionData') raw: string,
+  ): Promise<IdeasSectionResponseDto> {
+    this.logger.debug(`🚀 [PATCH /ideas-sections/${sectionId}/attach/${pageId}] Editando e vinculando seção`);
+
+    try {
+      if (!raw) throw new BadRequestException('sectionData é obrigatório.');
+
+      const parsedData = JSON.parse(Buffer.isBuffer(raw) ? raw.toString() : raw);
+      const dto = plainToInstance(UpdateIdeasSectionDto, parsedData);
+      const validationErrors = await validate(dto, {
+        whitelist: true,
+        forbidNonWhitelisted: true,
+      });
+
+      if (validationErrors.length > 0) {
+        this.logger.error('❌ Erros de validação:', JSON.stringify(validationErrors, null, 2));
+        throw new BadRequestException('Dados inválidos na requisição');
+      }
+
+      const filesDict: Record<string, Express.Multer.File> = {};
+      files.forEach((file) => (filesDict[file.fieldname] = file));
+
+      const result = await this.updateService.editAndAttachSectionToPage(sectionId, pageId, dto, filesDict);
+      this.logger.log(`✅ Seção editada e vinculada com sucesso: ID=${result.id}`);
+      return result;
+    } catch (error) {
+      this.logger.error('❌ Erro ao editar e vincular seção', error);
+      throw new BadRequestException('Erro ao editar e vincular a seção de ideias.');
+    }
+  }
+
+  @UseGuards(JwtAuthGuard, AdminRoleGuard)
+  @Delete(':id')
+  async delete(@Param('id') id: string) {
+    this.logger.debug(`🚀 Removendo seção de ideias ID=${id}`);
+
+    await this.deleteService.deleteSection(id);
+    this.logger.log(`✅ Seção de ideias removida com ID=${id}`);
+
+    return { message: 'Seção de ideias removida com sucesso.' };
+  }
+
+  @Get(':id')
+  async getById(@Param('id') id: string): Promise<IdeasSectionResponseDto> {
+    this.logger.debug(`🚀 Buscando seção de ideias ID=${id}`);
+
+    const result = await this.getService.findOne(id);
+    if (!result) {
+      throw new NotFoundException(`Seção de ideias com id=${id} não encontrada`);
+    }
+
+    this.logger.log(`✅ Seção de ideias encontrada ID=${id}`);
+    return result;
+  }
+
+  @Get()
+  async getAll(): Promise<IdeasSectionResponseDto[]> {
+    this.logger.debug('🚀 Listando todas as seções de ideias órfãs');
+
+    const result = await this.getService.findAll();
+    this.logger.log(`✅ ${result.length} seções de ideias encontradas`);
+    return result;
+  }
+
+}

--- a/src/pages/ideas-section/ideas-section.module.ts
+++ b/src/pages/ideas-section/ideas-section.module.ts
@@ -1,0 +1,32 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { IdeasSectionController } from './ideas-section.controller';
+import { IdeasSectionCreateService } from './services/ideas-section-create.service';
+import { IdeasSectionUpdateService } from './services/ideas-section-update.service';
+import { IdeasSectionGetService } from './services/ideas-section-get.service';
+import { IdeasSectionDeleteService } from './services/ideas-section-delete.service';
+import { IdeasSectionRepository } from './repository/ideas-section.repository';
+import { IdeasSectionEntity } from '../ideas-page/entities/ideas-section.entity';
+import { AwsModule } from 'src/aws/aws.module';
+import { MediaModule } from 'src/share/media/media.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([IdeasSectionEntity]),
+    AwsModule,
+    MediaModule,
+  ],
+  controllers: [IdeasSectionController],
+  providers: [
+    IdeasSectionCreateService,
+    IdeasSectionUpdateService,
+    IdeasSectionGetService,
+    IdeasSectionDeleteService,
+    IdeasSectionRepository,
+  ],
+  exports: [
+    IdeasSectionRepository,
+    IdeasSectionGetService,
+  ],
+})
+export class IdeasSectionModule { }

--- a/src/pages/ideas-section/repository/ideas-section.repository.ts
+++ b/src/pages/ideas-section/repository/ideas-section.repository.ts
@@ -1,0 +1,45 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { DataSource, Repository, IsNull } from 'typeorm';
+import { IdeasSectionEntity } from '../../ideas-page/entities/ideas-section.entity';
+
+@Injectable()
+export class IdeasSectionRepository extends Repository<IdeasSectionEntity> {
+  constructor(private readonly dataSource: DataSource) {
+    super(IdeasSectionEntity, dataSource.createEntityManager());
+  }
+
+  async findByPageId(pageId: string): Promise<IdeasSectionEntity[]> {
+    return this.find({
+      where: { page: { id: pageId } },
+      relations: ['page'],
+    });
+  }
+
+  async findAllOrphanSections(): Promise<IdeasSectionEntity[]> {
+    return this.find({
+      where: { page: IsNull() },
+    });
+  }
+
+  async upsertSection(sectionData: Partial<IdeasSectionEntity>): Promise<IdeasSectionEntity> {
+    if (sectionData.id) {
+      const existing = await this.findOne({ where: { id: sectionData.id } });
+
+      if (!existing) {
+        throw new NotFoundException(`Seção de ideias com ID=${sectionData.id} não encontrada.`);
+      }
+
+      const merged = this.merge(existing, sectionData);
+      return this.save(merged);
+    }
+
+    const created = this.create(sectionData);
+    return this.save(created);
+  }
+
+  async findAllOrfaSections(): Promise<IdeasSectionEntity[]> {
+    return this.find({
+      where: { page: IsNull() },
+    });
+  }
+}

--- a/src/pages/ideas-section/services/ideas-section-create.service.ts
+++ b/src/pages/ideas-section/services/ideas-section-create.service.ts
@@ -1,0 +1,134 @@
+import { Injectable, Logger, BadRequestException } from '@nestjs/common';
+import { DataSource, QueryRunner } from 'typeorm';
+import { AwsS3Service } from 'src/aws/aws-s3.service';
+import { MediaItemProcessor } from 'src/share/media/media-item-processor';
+import { UploadType } from 'src/share/media/media-item/media-item.entity';
+import { IdeasSectionMediaType } from '../enums/ideas-section-media-type.enum';
+import { MediaTargetType } from 'src/share/media/media-target-type.enum';
+import { IdeasSectionRepository } from '../repository/ideas-section.repository';
+import { CreateIdeasSectionDto } from '../dto/create-ideas-section.dto';
+import { MediaItemEntity } from 'src/share/media/media-item/media-item.entity';
+import { IdeasSectionResponseDto } from '../dto/ideas-section-response.dto';
+import { IdeasSectionEntity } from 'src/pages/ideas-page/entities/ideas-section.entity';
+
+@Injectable()
+export class IdeasSectionCreateService {
+  private readonly logger = new Logger(IdeasSectionCreateService.name);
+
+  constructor(
+    private readonly dataSource: DataSource,
+    private readonly awsS3Service: AwsS3Service,
+    private readonly mediaItemProcessor: MediaItemProcessor,
+    private readonly ideasSectionRepository: IdeasSectionRepository,
+  ) { }
+
+  async createSection(
+    dto: CreateIdeasSectionDto,
+    filesDict: Record<string, Express.Multer.File>,
+  ): Promise<IdeasSectionResponseDto> {
+    this.logger.verbose(`→ createIdeasSection | title="${dto.title}"`);
+
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+    this.logger.debug('▶️  Transaction started');
+
+    try {
+      const section = await this.persistOrphanSection(queryRunner, dto);
+      await this.processOrphanSectionMedia(section, dto, filesDict);
+
+      await queryRunner.commitTransaction();
+      this.logger.debug('✅  Transaction committed');
+
+      const mediaItems = await queryRunner.manager.find(MediaItemEntity, {
+        where: {
+          targetId: section.id,
+          targetType: MediaTargetType.IdeasSection,
+        },
+      });
+
+      return IdeasSectionResponseDto.fromEntity(section, mediaItems);
+    } catch (error) {
+      await queryRunner.rollbackTransaction();
+      this.logger.error('💥  Transaction rolled‑back', error.stack);
+      throw new BadRequestException(`Erro ao criar a seção de ideias: ${error.message}`);
+    } finally {
+      await queryRunner.release();
+      this.logger.debug('⛔  QueryRunner released');
+    }
+  }
+
+  private async persistOrphanSection(
+    queryRunner: QueryRunner,
+    dto: CreateIdeasSectionDto,
+  ): Promise<IdeasSectionEntity> {
+    this.logger.debug('📝 persistOrphanSection() - Extraído do IdeasPageCreateService');
+
+    const sectionRepo = queryRunner.manager.getRepository(IdeasSectionEntity);
+
+    const section = sectionRepo.create({
+      title: dto.title,
+      description: dto.description,
+      public: dto.public ?? true,
+      page: undefined,
+    });
+
+    const savedSection = await sectionRepo.save(section);
+    this.logger.debug(`   ↳ Orphan section saved (ID=${savedSection.id})`);
+
+    return savedSection;
+  }
+
+  private async processOrphanSectionMedia(
+    section: IdeasSectionEntity,
+    dto: CreateIdeasSectionDto,
+    filesDict: Record<string, Express.Multer.File>,
+  ): Promise<void> {
+    this.logger.debug('🎞️ processOrphanSectionMedia() - Extraído do IdeasPageCreateService');
+
+    if (!dto.medias?.length) {
+      this.logger.debug(`   ↳ section (ID=${section.id}) sem itens`);
+      return;
+    }
+
+    this.logger.debug(`   ↳ section (ID=${section.id}) | items=${dto.medias.length}`);
+
+    const normalized = dto.medias.map((item) => ({
+      ...item,
+      mediaType:
+        item.mediaType === IdeasSectionMediaType.VIDEO ? 'video' :
+          item.mediaType === IdeasSectionMediaType.DOCUMENT ? 'document' :
+            'image',
+      type: item.uploadType,
+      fileField:
+        item.uploadType === 'upload' && item.isLocalFile
+          ? item.fieldKey
+          : undefined,
+    }));
+
+    this.logger.debug(`🔄 Normalized items: ${JSON.stringify(normalized.map(item => ({ title: item.title, fileField: item.fileField, fieldKey: item.fieldKey })))}`);
+
+    const saved = await this.mediaItemProcessor.processMediaItemsPolymorphic(
+      normalized,
+      section.id,
+      MediaTargetType.IdeasSection,
+      filesDict,
+      this.awsS3Service.upload.bind(this.awsS3Service),
+    );
+
+    this.logger.debug(`       • ${saved.length} mídias processadas`);
+  }
+
+  private validateFiles(dto: CreateIdeasSectionDto, filesDict: Record<string, Express.Multer.File>) {
+    for (const media of dto.medias) {
+      if (media.uploadType === UploadType.UPLOAD && media.isLocalFile) {
+        if (!media.originalName) {
+          throw new BadRequestException('Campo originalName ausente');
+        }
+        if (!media.fieldKey || !filesDict[media.fieldKey]) {
+          throw new BadRequestException(`Arquivo não encontrado para fieldKey: ${media.fieldKey}`);
+        }
+      }
+    }
+  }
+}

--- a/src/pages/ideas-section/services/ideas-section-delete.service.ts
+++ b/src/pages/ideas-section/services/ideas-section-delete.service.ts
@@ -1,0 +1,90 @@
+import { Injectable, Logger, NotFoundException, BadRequestException } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { AwsS3Service } from 'src/aws/aws-s3.service';
+import { IdeasSectionRepository } from '../repository/ideas-section.repository';
+import { IdeasSectionEntity } from 'src/pages/ideas-page/entities/ideas-section.entity';
+import { MediaItemEntity } from 'src/share/media/media-item/media-item.entity';
+import { MediaTargetType } from 'src/share/media/media-target-type.enum';
+import { MediaItemProcessor } from 'src/share/media/media-item-processor';
+
+@Injectable()
+export class IdeasSectionDeleteService {
+  private readonly logger = new Logger(IdeasSectionDeleteService.name);
+
+  constructor(
+    private readonly dataSource: DataSource,
+    private readonly awsS3Service: AwsS3Service,
+    private readonly ideasSectionRepository: IdeasSectionRepository,
+    private readonly mediaItemProcessor: MediaItemProcessor,
+  ) { }
+
+  async deleteSection(id: string): Promise<void> {
+    this.logger.log(`🚀 Iniciando exclusão de seção de ideias ID=${id}`);
+
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    try {
+      const existingSection = await queryRunner.manager.findOne(IdeasSectionEntity, {
+        where: { id },
+      });
+
+      if (!existingSection) {
+        throw new NotFoundException(`Seção de ideias com ID=${id} não encontrada`);
+      }
+
+      if (existingSection.page) {
+        throw new BadRequestException(
+          `Seção de ideias ID=${id} está vinculada à página ID=${existingSection.page.id}. ` +
+          `Remova a vinculação primeiro ou delete a página.`
+        );
+      }
+
+      const mediaItems = await queryRunner.manager.find(MediaItemEntity, {
+        where: {
+          targetId: id,
+          targetType: MediaTargetType.IdeasSection,
+        },
+      });
+
+      for (const media of mediaItems) {
+        if (media.isLocalFile && media.url) {
+          this.logger.debug(`🗑️ Removendo arquivo do S3: ${media.url}`);
+          try {
+            await this.awsS3Service.delete(media.url);
+            this.logger.debug(`✅ Arquivo removido do S3: ${media.url}`);
+          } catch (error) {
+            this.logger.warn(`⚠️ Erro ao remover arquivo do S3: ${media.url}`, error);
+          }
+        }
+      }
+
+      if (mediaItems.length > 0) {
+        await queryRunner.manager.delete(MediaItemEntity, {
+          targetId: id,
+          targetType: MediaTargetType.IdeasSection,
+        });
+        this.logger.debug(`✅ ${mediaItems.length} mídias removidas do banco`);
+      }
+
+      await queryRunner.manager.delete(IdeasSectionEntity, { id });
+      this.logger.debug(`✅ Seção de ideias ID=${id} removida do banco`);
+
+      await queryRunner.commitTransaction();
+      this.logger.log(`✅ Seção de ideias ID=${id} excluída com sucesso`);
+
+    } catch (error) {
+      await queryRunner.rollbackTransaction();
+      this.logger.error(`❌ Erro ao excluir seção de ideias ID=${id}`, error);
+
+      if (error instanceof NotFoundException || error instanceof BadRequestException) {
+        throw error;
+      }
+
+      throw new BadRequestException('Erro ao excluir a seção de ideias');
+    } finally {
+      await queryRunner.release();
+    }
+  }
+}

--- a/src/pages/ideas-section/services/ideas-section-get.service.ts
+++ b/src/pages/ideas-section/services/ideas-section-get.service.ts
@@ -1,0 +1,79 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { IdeasSectionRepository } from '../repository/ideas-section.repository';
+import { IdeasSectionEntity } from 'src/pages/ideas-page/entities/ideas-section.entity';
+import { IdeasSectionResponseDto } from '../dto/ideas-section-response.dto';
+import { MediaItemEntity } from 'src/share/media/media-item/media-item.entity';
+import { MediaItemProcessor } from 'src/share/media/media-item-processor';
+import { MediaTargetType } from 'src/share/media/media-target-type.enum';
+
+@Injectable()
+export class IdeasSectionGetService {
+  private readonly logger = new Logger(IdeasSectionGetService.name);
+
+  constructor(
+    private readonly ideasSectionRepository: IdeasSectionRepository,
+    private readonly mediaItemProcessor: MediaItemProcessor,
+  ) { }
+
+  async findOne(id: string): Promise<IdeasSectionResponseDto | null> {
+    this.logger.debug(`🔍 Buscando seção de ideias ID=${id}`);
+
+    const section = await this.ideasSectionRepository.findOne({
+      where: { id },
+    });
+
+    if (!section) {
+      this.logger.warn(`⚠️ Seção de ideias ID=${id} não encontrada`);
+      return null;
+    }
+
+    const medias = await this.mediaItemProcessor.findManyMediaItemsByTargets(
+      [id],
+      MediaTargetType.IdeasSection,
+    );
+
+    this.logger.debug(`✅ Seção de ideias encontrada: ID=${id}, title="${section.title}"`);
+    return IdeasSectionResponseDto.fromEntity(section, medias);
+  }
+
+  async findAll(): Promise<IdeasSectionResponseDto[]> {
+    this.logger.debug('🔍 Buscando todas as seções de ideias órfãs');
+
+    const sections = await this.ideasSectionRepository.findAllOrphanSections();
+
+    if (!sections || sections.length === 0) {
+      this.logger.debug('📭 Nenhuma seção de ideias órfã encontrada');
+      return [];
+    }
+
+    const sectionIds = sections.map(section => section.id);
+    const allMedias = await this.mediaItemProcessor.findManyMediaItemsByTargets(
+      sectionIds,
+      MediaTargetType.IdeasSection,
+    );
+
+    const mediaMap = this.groupMediaBySectionId(allMedias);
+
+    const result = sections.map(section => {
+      const sectionMedias = mediaMap.get(section.id) || [];
+      return IdeasSectionResponseDto.fromEntity(section, sectionMedias);
+    });
+
+    this.logger.debug(`✅ ${result.length} seções de ideias órfãs encontradas`);
+    return result;
+  }
+
+  private groupMediaBySectionId(mediaItems: MediaItemEntity[]): Map<string, MediaItemEntity[]> {
+    const mediaMap = new Map<string, MediaItemEntity[]>();
+
+    for (const media of mediaItems) {
+      const sectionId = media.targetId;
+      if (!mediaMap.has(sectionId)) {
+        mediaMap.set(sectionId, []);
+      }
+      mediaMap.get(sectionId)!.push(media);
+    }
+
+    return mediaMap;
+  }
+}

--- a/src/pages/ideas-section/services/ideas-section-update.service.ts
+++ b/src/pages/ideas-section/services/ideas-section-update.service.ts
@@ -1,0 +1,439 @@
+import { Injectable, Logger, BadRequestException, NotFoundException } from '@nestjs/common';
+import { DataSource, QueryRunner } from 'typeorm';
+import { AwsS3Service } from 'src/aws/aws-s3.service';
+import { MediaItemProcessor } from 'src/share/media/media-item-processor';
+import { UploadType } from 'src/share/media/media-item/media-item.entity';
+import { IdeasSectionMediaType } from '../enums/ideas-section-media-type.enum';
+import { MediaTargetType } from 'src/share/media/media-target-type.enum';
+import { IdeasSectionRepository } from '../repository/ideas-section.repository';
+import { UpdateIdeasSectionDto } from '../dto/update-ideas-section.dto';
+import { IdeasSectionMediaItemDto } from '../dto/ideas-section-media-item.dto';
+import { MediaItemEntity } from 'src/share/media/media-item/media-item.entity';
+import { IdeasSectionResponseDto } from '../dto/ideas-section-response.dto';
+import { IdeasSectionEntity } from 'src/pages/ideas-page/entities/ideas-section.entity';
+import { IdeasPageEntity } from 'src/pages/ideas-page/entities/ideas-page.entity';
+
+@Injectable()
+export class IdeasSectionUpdateService {
+  private readonly logger = new Logger(IdeasSectionUpdateService.name);
+
+  constructor(
+    private readonly dataSource: DataSource,
+    private readonly awsS3Service: AwsS3Service,
+    private readonly mediaItemProcessor: MediaItemProcessor,
+    private readonly ideasSectionRepository: IdeasSectionRepository,
+  ) { }
+
+  async updateSection(
+    id: string,
+    dto: UpdateIdeasSectionDto,
+    filesDict: Record<string, Express.Multer.File>,
+  ): Promise<IdeasSectionResponseDto> {
+    this.logger.log(`🚀 Iniciando atualização de seção de ideias ID=${id}`);
+
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    try {
+      const existingSection = await this.validateSection(id, queryRunner);
+
+      const existingMedia = await this.validateMedia([id], queryRunner);
+      const savedSection = await this.upsertSection(dto, existingSection.page, queryRunner);
+      const normalized = (dto.medias || []).map((item) => ({
+        ...item,
+        mediaType:
+          item.mediaType === IdeasSectionMediaType.VIDEO ? 'video' :
+            item.mediaType === IdeasSectionMediaType.DOCUMENT ? 'document' :
+              'image',
+        uploadType: item.uploadType,
+        fileField:
+          item.uploadType === 'upload' && item.isLocalFile
+            ? item.fieldKey
+            : undefined,
+      }));
+
+      this.logger.debug(`🖼️ Processando ${dto.medias.length} mídias`);
+      const processedMedia = await this.processSectionMedia(
+        dto.medias || [],
+        savedSection.id,
+        existingMedia,
+        filesDict,
+        queryRunner,
+      );
+
+      await queryRunner.commitTransaction();
+
+      return IdeasSectionResponseDto.fromEntity(savedSection, processedMedia);
+    } catch (error) {
+      await queryRunner.rollbackTransaction();
+      this.logger.error('❌ Erro ao atualizar seção', error);
+
+      if (error instanceof NotFoundException || error instanceof BadRequestException) {
+        throw error;
+      }
+
+      throw new BadRequestException('Erro ao atualizar a seção de ideias');
+    } finally {
+      await queryRunner.release();
+    }
+  }
+
+  async editAndAttachSectionToPage(
+    sectionId: string,
+    pageId: string,
+    dto: UpdateIdeasSectionDto,
+    filesDict: Record<string, Express.Multer.File>,
+  ): Promise<IdeasSectionResponseDto> {
+    this.logger.log(`🚀 Editando e vinculando seção órfã ID=${sectionId} à página ID=${pageId}`);
+
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    try {
+      const existingSection = await queryRunner.manager.findOne(IdeasSectionEntity, {
+        where: { id: sectionId },
+      });
+
+      if (!existingSection) {
+        throw new NotFoundException(`Seção de ideias com ID=${sectionId} não encontrada`);
+      }
+      if (existingSection.page) {
+        throw new BadRequestException(
+          `Seção ID=${sectionId} já está vinculada à página ID=${existingSection.page.id}`
+        );
+      }
+
+      const ideasPage = await queryRunner.manager.findOne(IdeasPageEntity, {
+        where: { id: pageId },
+      });
+
+      if (!ideasPage) {
+        throw new NotFoundException(`Página de ideias com ID=${pageId} não encontrada`);
+      }
+
+      const existingMedia = await queryRunner.manager.find(MediaItemEntity, {
+        where: {
+          targetId: sectionId,
+          targetType: MediaTargetType.IdeasSection,
+        },
+      });
+
+      this.validateFiles(dto, filesDict);
+
+      const updatedSection = queryRunner.manager.merge(IdeasSectionEntity, existingSection, {
+        title: dto.title,
+        description: dto.description,
+        public: dto.public,
+        page: ideasPage,
+      });
+
+      const savedSection = await queryRunner.manager.save(updatedSection);
+
+      const normalized = dto.medias.map((item) => ({
+        ...item,
+        mediaType:
+          item.mediaType === IdeasSectionMediaType.VIDEO ? 'video' :
+            item.mediaType === IdeasSectionMediaType.DOCUMENT ? 'document' :
+              'image',
+        uploadType: item.uploadType,
+        fileField:
+          item.uploadType === 'upload' && item.isLocalFile
+            ? item.fieldKey
+            : undefined,
+      }));
+
+      this.logger.debug(`📊 Dados para processamento:`);
+      this.logger.debug(`   - Mídias no payload: ${dto.medias.length}`);
+      this.logger.debug(`   - Mídias existentes: ${existingMedia.length}`);
+      this.logger.debug(`   - Mídias normalizadas: ${normalized.length}`);
+      this.logger.debug(`   - IDs no payload: ${dto.medias.map(m => m.id).join(', ')}`);
+      this.logger.debug(`   - IDs existentes: ${existingMedia.map(m => m.id).join(', ')}`);
+
+      this.logger.debug(`🗑️ Iniciando exclusão de mídias obsoletas`);
+      await this.deleteMedia(existingMedia, dto.medias, queryRunner);
+      this.logger.debug(`✅ Exclusão de mídias concluída com sucesso`);
+
+      this.logger.debug(`🖼️ Processando ${dto.medias.length} mídias`);
+      const processedMedia = await this.processSectionMedia(
+        dto.medias || [],
+        savedSection.id,
+        existingMedia,
+        filesDict,
+        queryRunner,
+      );
+
+      ideasPage.sections = [...(ideasPage.sections || []), savedSection];
+      await queryRunner.manager.save(IdeasPageEntity, ideasPage);
+
+      await queryRunner.commitTransaction();
+
+      this.logger.log(`✅ Seção ID=${sectionId} editada e vinculada à página ID=${pageId} com sucesso`);
+      return IdeasSectionResponseDto.fromEntity(savedSection, processedMedia);
+
+    } catch (error) {
+      await queryRunner.rollbackTransaction();
+      this.logger.error('❌ Erro ao editar e vincular seção', error);
+
+      if (error instanceof NotFoundException || error instanceof BadRequestException) {
+        throw error;
+      }
+
+      throw new BadRequestException('Erro ao editar e vincular a seção de ideias');
+    } finally {
+      await queryRunner.release();
+    }
+  }
+
+  private async validateSection(id: string, queryRunner: any): Promise<IdeasSectionEntity> {
+    this.logger.debug(`🔍 Buscando seção com ID: ${id} no banco de dados`);
+    const section = await queryRunner.manager.findOne(IdeasSectionEntity, {
+      where: { id },
+      relations: ['page'],
+    });
+    if (!section) {
+      this.logger.warn(`⚠️ Seção com ID ${id} não encontrada`);
+      throw new NotFoundException('Seção de ideias não encontrada');
+    }
+    this.logger.debug(`✅ Seção encontrada e validada: ID=${section.id}, title="${section.title}"`);
+    return section;
+  }
+
+  private async validateMedia(sectionIds: string[], queryRunner: any): Promise<MediaItemEntity[]> {
+    this.logger.debug(`🔍 Buscando mídias para seções: ${sectionIds.join(', ')}`);
+    const media = await queryRunner.manager.find(MediaItemEntity, {
+      where: {
+        targetId: sectionIds[0],
+        targetType: MediaTargetType.IdeasSection,
+      },
+    });
+    this.logger.debug(`✅ ${media.length} mídias encontradas e validadas: ${media.map(m => `ID=${m.id}`).join(', ')}`);
+    return media;
+  }
+
+  private async upsertSection(
+    sectionInput: UpdateIdeasSectionDto,
+    page: IdeasPageEntity | null,
+    queryRunner: any,
+  ): Promise<IdeasSectionEntity> {
+    this.logger.debug(`🔄 Preparando upsert de seção: title="${sectionInput.title}"`);
+    const sectionToUpsert: Partial<IdeasSectionEntity> = {
+      title: sectionInput.title,
+      description: sectionInput.description,
+      public: sectionInput.public ?? true,
+      page: page || undefined,
+    };
+    this.logger.debug(`💾 Salvando seção no banco com dados: ${JSON.stringify(sectionToUpsert)}`);
+    const savedSection = await queryRunner.manager.save(IdeasSectionEntity, sectionToUpsert);
+    this.logger.debug(`✅ Seção upsertada com sucesso: ID=${savedSection.id}, title="${savedSection.title}"`);
+    return savedSection;
+  }
+
+
+
+  private validateFiles(dto: UpdateIdeasSectionDto, filesDict: Record<string, Express.Multer.File>) {
+    for (const media of dto.medias) {
+      if (media.uploadType === UploadType.UPLOAD && media.isLocalFile && (!media.id || media.fieldKey)) {
+        if (!media.originalName) {
+          throw new BadRequestException('Campo originalName ausente');
+        }
+        if (media.fieldKey && !filesDict[media.fieldKey]) {
+          throw new BadRequestException(`Arquivo não encontrado para fieldKey: ${media.fieldKey}`);
+        }
+      }
+    }
+  }
+
+  private async deleteMedia(
+    existingMedia: MediaItemEntity[],
+    requestedMedias: IdeasSectionMediaItemDto[],
+    queryRunner: QueryRunner,
+  ): Promise<void> {
+    this.logger.debug(`🗑️ Identificando mídias para remoção`);
+    const requestedMediaIds = requestedMedias
+      .map(media => media.id)
+      .filter((id): id is string => typeof id === 'string' && id.length > 0);
+    this.logger.debug(`📋 IDs de mídias recebidas: ${requestedMediaIds.join(', ') || 'nenhum'}`);
+
+    const mediaToRemove = existingMedia.filter(
+      existing => existing.id && !requestedMediaIds.includes(existing.id),
+    );
+    this.logger.debug(
+      `🗑️ ${mediaToRemove.length} mídias marcadas para remoção: ${mediaToRemove.map(m => m.id).join(', ')}`,
+    );
+
+    for (const media of mediaToRemove) {
+      if (!media.id) {
+        this.logger.warn(`⚠️ Mídia sem ID detectada, pulando exclusão: URL=${media.url || 'desconhecida'}`);
+        continue;
+      }
+      this.logger.debug(`🗑️ Iniciando remoção da mídia ID: ${media.id}, URL="${media.url || 'não fornecida'}"`);
+
+      if (media.isLocalFile && media.url) {
+        this.logger.debug(`🗑️ Removendo arquivo do S3: ${media.url}`);
+        try {
+          await this.awsS3Service.delete(media.url);
+          this.logger.debug(`✅ Arquivo removido do S3 com sucesso: ${media.url}`);
+        } catch (error) {
+          this.logger.error(`❌ Falha ao remover arquivo do S3: ${media.url}`, error.stack);
+          throw new BadRequestException(`Falha ao remover arquivo do S3: ${media.url}`);
+        }
+      }
+
+      this.logger.debug(`🗑️ Removendo mídia do banco de dados: ID=${media.id}`);
+      await queryRunner.manager.delete(MediaItemEntity, { id: media.id });
+      this.logger.debug(`✅ Mídia removida do banco com sucesso: ID=${media.id}`);
+    }
+    this.logger.debug(`✅ Processo de remoção de mídias concluído`);
+  }
+
+  private async processSectionMedia(
+    mediaItems: IdeasSectionMediaItemDto[],
+    sectionId: string,
+    oldMedia: MediaItemEntity[],
+    filesDict: Record<string, Express.Multer.File>,
+    queryRunner: QueryRunner,
+  ): Promise<MediaItemEntity[]> {
+    this.logger.debug(`📽️ Iniciando processamento de ${mediaItems.length} mídias para seção ID: ${sectionId}`);
+    const processedMedia: MediaItemEntity[] = [];
+
+    for (const mediaInput of mediaItems) {
+      this.logger.debug(
+        `📽️ Processando mídia: id=${mediaInput.id || 'novo'}, fieldKey="${mediaInput.fieldKey || 'não fornecido'}", mediaType=${mediaInput.mediaType}, uploadType=${mediaInput.uploadType}`,
+      );
+
+      if (mediaInput.id) {
+        this.logger.debug(`🔄 Iniciando upsert de mídia existente com ID: ${mediaInput.id}`);
+        const savedMedia = await this.upsertMedia(mediaInput, sectionId, filesDict, queryRunner);
+        processedMedia.push(savedMedia);
+        this.logger.debug(
+          `✅ Mídia upsertada com sucesso: ID=${savedMedia.id}, URL=${savedMedia.url}, targetId=${savedMedia.targetId}, targetType=${savedMedia.targetType}`,
+        );
+      } else {
+        this.logger.debug(
+          `🆕 Iniciando adição de nova mídia: fieldKey="${mediaInput.fieldKey || 'não fornecido'}"`,
+        );
+        const savedMedia = await this.addMedia(mediaInput, sectionId, filesDict, queryRunner);
+        processedMedia.push(savedMedia);
+        this.logger.debug(
+          `✅ Nova mídia adicionada com sucesso: ID=${savedMedia.id}, URL=${savedMedia.url}, targetId=${savedMedia.targetId}, targetType=${savedMedia.targetType}`,
+        );
+      }
+    }
+
+    this.logger.debug(
+      `✅ Processamento de mídias concluído: ${processedMedia.length} mídias processadas para seção ID: ${sectionId}`,
+    );
+    return processedMedia;
+  }
+
+  private async addMedia(
+    mediaInput: IdeasSectionMediaItemDto,
+    targetId: string,
+    filesDict: Record<string, Express.Multer.File>,
+    queryRunner: QueryRunner,
+  ): Promise<MediaItemEntity> {
+    this.logger.debug(`🆕 Construindo nova mídia: "${mediaInput.title || 'não fornecido'}"`);
+
+    const media = this.mediaItemProcessor.buildBaseMediaItem(
+      { ...mediaInput, mediaType: mediaInput.mediaType as any || IdeasSectionMediaType.IMAGE },
+      targetId,
+      MediaTargetType.IdeasSection,
+    );
+
+    if (mediaInput.uploadType === UploadType.UPLOAD || mediaInput.isLocalFile === true) {
+      media.platformType = undefined;
+      if (!mediaInput.fieldKey) {
+        this.logger.error(`❌ FieldKey ausente para mídia "${mediaInput.title}"`);
+        throw new BadRequestException(`FieldKey ausente para mídia "${mediaInput.title}"`);
+      }
+      const file = filesDict[mediaInput.fieldKey];
+      if (!file) {
+        this.logger.error(`❌ Arquivo ausente para mídia "${mediaInput.title}" (fieldKey: ${mediaInput.fieldKey})`);
+        throw new BadRequestException(`Arquivo ausente para mídia "${mediaInput.title}"`);
+      }
+      this.logger.debug(`⬆️ Fazendo upload da mídia "${file.originalname}" para S3`);
+      media.url = await this.awsS3Service.upload(file);
+      media.isLocalFile = mediaInput.isLocalFile;
+      media.originalName = file.originalname;
+      media.size = file.size;
+      this.logger.debug(`✅ Upload concluído. URL=${media.url}`);
+    } else {
+      media.title = mediaInput.title || media.title;
+      media.description = mediaInput.description || media.description;
+      media.uploadType = mediaInput.uploadType || media.uploadType;
+      media.platformType = mediaInput.platformType || media.platformType;
+      media.mediaType = (mediaInput.mediaType as any) || media.mediaType;
+      media.url = mediaInput.url?.trim() || media.url;
+      media.originalName = mediaInput.originalName || media.originalName;
+      media.isLocalFile = mediaInput.isLocalFile || media.isLocalFile;
+      media.size = mediaInput.size || media.size;
+      this.logger.debug(`🔗 Usando URL externa para mídia: "${media.url}"`);
+    }
+
+    this.logger.debug(`💾 Salvando mídia no banco`);
+    const savedMedia = await this.mediaItemProcessor.saveMediaItem(media);
+    this.logger.debug(`✅ Mídia salva com ID=${savedMedia.id}`);
+    return savedMedia;
+  }
+
+  private async upsertMedia(
+    mediaInput: IdeasSectionMediaItemDto,
+    targetId: string,
+    filesDict: Record<string, Express.Multer.File>,
+    queryRunner: QueryRunner,
+  ): Promise<MediaItemEntity> {
+    this.logger.debug(
+      `🔄 Iniciando upsert de mídia: ID=${mediaInput.id || 'novo'}, fieldKey="${mediaInput.fieldKey || 'não fornecido'}"`,
+    );
+    this.logger.debug(`📋 Construindo base da mídia para targetId: ${targetId}`);
+
+    const media = this.mediaItemProcessor.buildBaseMediaItem(
+      { ...mediaInput, mediaType: mediaInput.mediaType as any },
+      targetId,
+      MediaTargetType.IdeasSection,
+    );
+
+    if (mediaInput.isLocalFile && !mediaInput.id && mediaInput.uploadType === UploadType.UPLOAD) {
+      this.logger.debug(`🔍 Verificando arquivo para upload: fieldKey=${mediaInput.fieldKey || mediaInput.url}`);
+      const key = mediaInput.fieldKey ?? mediaInput.url;
+      if (!key) {
+        this.logger.error(`❌ Arquivo ausente para upload: nenhum fieldKey ou url fornecido`);
+        throw new BadRequestException(`Arquivo ausente para upload: nenhum fieldKey ou url fornecido`);
+      }
+      const file = filesDict[key];
+      if (!file) {
+        this.logger.error(`❌ Arquivo não encontrado para chave: ${key}`);
+        throw new BadRequestException(`Arquivo não encontrado para upload: ${key}`);
+      }
+      this.logger.debug(`📤 Iniciando upload do arquivo para S3: ${file.originalname}`);
+      media.url = await this.awsS3Service.upload(file);
+      media.originalName = file.originalname;
+      media.isLocalFile = mediaInput.isLocalFile;
+      media.size = file.size;
+      this.logger.debug(`✅ Upload concluído com sucesso, URL: ${media.url}`);
+    } else {
+      media.title = mediaInput.title || media.title;
+      media.description = mediaInput.description || media.description;
+      media.uploadType = mediaInput.uploadType || media.uploadType;
+      media.platformType = mediaInput.platformType || media.platformType;
+      media.mediaType = (mediaInput.mediaType as any) || media.mediaType;
+      media.url = mediaInput.url?.trim() || media.url;
+      media.originalName = mediaInput.originalName || media.originalName;
+      media.isLocalFile = mediaInput.isLocalFile || media.isLocalFile;
+      media.size = mediaInput.size || media.size;
+      this.logger.debug(`🔗 Usando URL externa para mídia: "${media.url}"`);
+    }
+
+    this.logger.debug(`💾 Salvando mídia no banco com dados: ${JSON.stringify(media)}`);
+    const savedMedia = await queryRunner.manager.save(MediaItemEntity, {
+      ...media,
+      id: mediaInput.id,
+    });
+    this.logger.debug(
+      `✅ Mídia upsertada com sucesso: ID=${savedMedia.id}, URL=${savedMedia.url}, targetId=${savedMedia.targetId}, targetType=${savedMedia.targetType}`,
+    );
+    return savedMedia;
+  }
+}


### PR DESCRIPTION
- Created DTOs for Ideas Section media items and responses.
- Implemented controller for managing Ideas Sections with endpoints for create, update, delete, and retrieve operations.
- Developed services for creating, updating, deleting, and retrieving Ideas Sections, including media processing and validation.
- Added repository for database interactions with Ideas Sections.
- Introduced enums for media types specific to Ideas Sections.
- Integrated AWS S3 service for media file uploads and deletions.
- Implemented validation for incoming data using class-validator.
- Enhanced logging for better traceability of operations.